### PR TITLE
Download Artifact Version

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -35,7 +35,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Python Wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: aac_rest_api_wheel
           path: python/dist/

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rest-api"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
 	{ name="bunchw", email="asdfasdaf@email.com" },
 	{ name="lizzcondrey", email="asdfasdfd@mail.com" },


### PR DESCRIPTION
… discrepancy I think

# Description

Matching current action versions for upload and download artifacts, we're still on 3 right now. 

### Changed

- Download artifact version. 


# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
