### PR TITLE
Pypi deployment name fix

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = f"2021 - {str(date.today().year)} , AaC Rest-API Project Contributor
 author = "AaC Rest-API Project Contributors"
 
 # The full version, including alpha/beta/rc tags
-release = metadata.version("rest-api")
+release = metadata.version("aac-rest-api")
 
 
 # -- General configuration ---------------------------------------------------

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,8 +54,8 @@ test = [
 ]
 
 all = [
-	"rest-api[doc]",
-	"rest-api[test]"
+	"aac-rest-api[doc]",
+	"aac-rest-api[test]"
 ]
 
 [project.entry-points."aac"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aac-rest-api"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
 	{ name="AaC Dev Team", email="asdfasdaf@email.com" },
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,11 +3,10 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "rest-api"
+name = "aac-rest-api"
 version = "0.1.4"
 authors = [
-	{ name="bunchw", email="asdfasdaf@email.com" },
-	{ name="lizzcondrey", email="asdfasdfd@mail.com" },
+	{ name="AaC Dev Team", email="asdfasdaf@email.com" },
 ]
 description = "Rest-API Plugin for AaC"
 requires-python = ">= 3.9.13"
@@ -22,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-	"aac >= 0.4.3",
+	"aac >= 0.4.27",
 ]
 [project.optional-dependencies]
 doc = [
@@ -55,7 +54,6 @@ test = [
 ]
 
 all = [
-	"aac >= 0.4.8",
 	"rest-api[doc]",
 	"rest-api[test]"
 ]
@@ -63,8 +61,8 @@ all = [
 [project.entry-points."aac"]
 rest-api = "rest_api"
 [project.urls]
-Homepage = "https://github.com/DevOps-MBSE/rest-api"
-Issues = "https://github.com/DevOps-MBSE/rest-api/issues"
+Homepage = "https://github.com/DevOps-MBSE/aac-rest-api"
+Issues = "https://github.com/DevOps-MBSE/aac-rest-api/issues"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
# Description

Added `aac` preface to package name to follow project naming scheme for use with PyPi deployment and GitHub hosting. 

# Linked Items:

N/A

### Fixed

- Name reference for use with PyPi deployment to follow project naming scheme. 


# Checklist:

- [ ] I updated project documentation to reflect my changes.
- [ ] My changes generate no new warnings.
- [ ] I updated new and existing unit tests to account for my changes.
- [ ] I linked the associated item(s) to be closed.
- [x] I bumped the version.
- [x] I added the labels corresponding to my changes.
